### PR TITLE
Added get Max Skyline Add

### DIFF
--- a/lc02-max-skyline.js
+++ b/lc02-max-skyline.js
@@ -1,0 +1,58 @@
+/**
+ * @param {number[][]} grid
+ * @return {number}
+ */
+var maxIncreaseKeepingSkyline = function (grid) {
+  let result = 0
+  
+  const limitColumn = []
+  const limitLine = [] 
+  
+  if (!grid || !grid.length) {
+    return 0
+  }
+  
+  let lineSize = 0
+  const heightSize = grid.length
+  
+  for (let i = 0; i < heightSize; i++) {
+    lineSize = grid[i].length
+    limitColumn[i] = getMaxVerticalSkyline(grid, i)
+  }
+  
+  for (let i = 0; i < lineSize; i++) {
+    limitLine[i] = getHorizontalSkyline(grid, i)
+  }
+  
+  for (let i = 0; i < heightSize; i++) {
+    for (let j = 0; j < lineSize; j++) {
+      if (limitColumn[i] > limitLine[j]) {
+        result += limitLine[j] - grid[i][j]      
+      } else {
+        result += limitColumn[i] - grid[i][j]
+      }
+    }
+  }
+  
+  return result
+};
+
+const getMaxVerticalSkyline = function (grid, columnIndex) {
+  let verticalMax = 0
+  for (let i = 0; i < grid.length; i++) {
+    if (grid[i][columnIndex] > verticalMax) {
+        verticalMax = grid[i][columnIndex]
+    }
+  }
+  return verticalMax
+};
+
+const getHorizontalSkyline = function (grid, lineIndex) {
+  let horizontalMax = 0
+  for (let i = 0; i < grid[lineIndex].length; i++) {
+    if (grid[lineIndex][i] > horizontalMax) {
+      horizontalMax = grid[lineIndex][i]
+    }
+  }
+  return horizontalMax
+}


### PR DESCRIPTION
In a 2 dimensional array grid, each value grid[i][j] represents the height of a building located there. We are allowed to increase the height of any number of buildings, by any amount (the amounts can be different for different buildings). Height 0 is considered to be a building as well. 

At the end, the "skyline" when viewed from all four directions of the grid, i.e. top, bottom, left, and right, must be the same as the skyline of the original grid. A city's skyline is the outer contour of the rectangles formed by all the buildings when viewed from a distance.

https://leetcode.com/problems/max-increase-to-keep-city-skyline/
